### PR TITLE
Update Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,14 @@
 super simple http server that will allow you 'mock' delays in HTTP requires (ie: dont know what the request will be, just that you need to have a little delay and a real connection)
 
 ## running (only works on amd64 docker arch)
+First will be to build an image from the Dockerfile included by running:
 ```
-docker run -p 3000:3000 nexusuw/delay-server:latest
+docker build -t delay-server .
 ```
-then vist [localhost:3000](http://localhost:3000)
+On successful build, you can go ahead to create a running container from the image
+```
+docker run -p 8080:8080 delay-server
+```
+then vist [localhost:8080](http://localhost:8080)
+
+


### PR DESCRIPTION
This PR updates the README to allow easier setup as the commands in the current README have two issues, first there's a port mismatch, the delay server runs on 8080 if building and running the image locally whereas the run command uses 3000, and also the old command was pulling a prebuilt image from a container registry rather than building and running locally